### PR TITLE
.github: workflows: Use zephyr-runner v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,40 +16,117 @@ concurrency:
 
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-22.04-4c
+    name: Build (${{ matrix.variant.platform }})
+    runs-on:
+      group: ${{ matrix.variant.builder }}
+    container:
+      image: ghcr.io/zephyrproject-rtos/image-build:v1.0.0
+
+    strategy:
+      fail-fast: true
+      matrix:
+        variant:
+        - platform: linux/amd64
+          arch: amd64
+          builder: zephyr-runner-v2-linux-x64-4xlarge
+        - platform: linux/arm64
+          arch: arm64
+          builder: zephyr-runner-v2-linux-arm64-4xlarge
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Generate metadata
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: |
           ghcr.io/zephyrproject-rtos/ci-repo-cache
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+        flavor: |
+          latest=false
+          suffix=-${{ matrix.variant.arch }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
 
     - name: Login to GitHub Container Registry
       if: ${{ github.event_name != 'pull_request' }}
-      uses: docker/login-action@v3
+      uses: redhat-actions/podman-login@v1
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+    - name: Build image
+      uses: redhat-actions/buildah-build@v2
       with:
         context: .
-        file: Dockerfile
-        platforms: linux/amd64,linux/arm64
-        push: ${{ github.event_name != 'pull_request' }}
+        containerfiles: Dockerfile
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Push image
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        tags: ${{ steps.meta.outputs.tags }}
+
+  merge:
+    name: Merge
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
+    container:
+      image: ghcr.io/zephyrproject-rtos/image-build:v1.0.0
+    needs: build
+    if: ${{ github.event_name != 'pull_request' }}
+
+    steps:
+    - name: Login to GitHub Container Registry
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Generate metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ghcr.io/zephyrproject-rtos/ci-repo-cache
+        flavor: |
+          latest=false
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Create multi-architecture image
+      run: |
+        archs=(amd64 arm64)
+        image="ghcr.io/zephyrproject-rtos/ci-repo-cache:${{ steps.meta.outputs.version }}"
+        image_tags="${{ steps.meta.outputs.tags }}"
+
+        # Pull architecture-specific image.
+        for arch in ${archs[@]}; do
+          podman pull ${image}-${arch}
+        done
+
+        # Create multi-architecture image.
+        for arch in ${archs[@]}; do
+          image_amend_flags+="--amend ${image}-${arch} "
+        done
+
+        podman manifest create ${image} ${image_amend_flags}
+
+        # Create image tags.
+        for tag in ${image_tags}; do
+          podman tag ${image} ${tag}
+        done
+
+    - name: Push image
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This commit updates the GitHub Actions CI workflow to use the new zephyr-runner v2.

As part of this, it also updates the workflow to use Buildah and Podman to build the ci-repo-cache image because the zephyr-runner v2 has stricter security requirements and do not support running privileged pods, which is necessary for launching Docker daemon.