### PR TITLE
Dockerfile: Use CI image v0.26.11 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/zephyrproject-rtos/ci:v0.26.9
+FROM ghcr.io/zephyrproject-rtos/ci:v0.26.11
 
 # Cache Zephyr repositories
 RUN mkdir -p /repo-cache/zephyrproject && \


### PR DESCRIPTION
This commit updates the Dockerfile to use the CI image v0.26.11 as the base image.