### PR TITLE
ci: Place container storage inside work volume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
           builder: zephyr-runner-v2-linux-arm64-4xlarge
 
     steps:
+    - name: Configure container storage
+      run: |
+        sed -i 's/graphroot = .*/graphroot = "\/__w\/container_storage"/' /etc/containers/storage.conf
+        mkdir -p /__w/container_storage
+
     - name: Checkout
       uses: actions/checkout@v4
 
@@ -83,6 +88,11 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
+    - name: Configure container storage
+      run: |
+        sed -i 's/graphroot = .*/graphroot = "\/__w\/container_storage"/' /etc/containers/storage.conf
+        mkdir -p /__w/container_storage
+
     - name: Login to GitHub Container Registry
       uses: redhat-actions/podman-login@v1
       with:


### PR DESCRIPTION
This commit updates the CI workflow to explicitly configure the Podman container storage to be inside the runner work volume (`__w`), which is guaranteed to have at least 100GB available.

The default container storage path is `/var/lib/containers/storage`, which resides in the Docker storage volume that has no free space guarantees.