### PR TITLE
.github: workflows: Set TMPDIR to under work volume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
           builder: zephyr-runner-v2-linux-arm64-4xlarge
 
     steps:
+    - name: Configure temporary directory
+      run: |
+        mkdir -p /__w/tmp
+        echo "TMPDIR=/__w/tmp" >> $GITHUB_ENV
+
     - name: Configure container storage
       run: |
         sed -i 's/graphroot = .*/graphroot = "\/__w\/container_storage"/' /etc/containers/storage.conf
@@ -88,6 +93,11 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
+    - name: Configure temporary directory
+      run: |
+        mkdir -p /__w/tmp
+        echo "TMPDIR=/__w/tmp" >> $GITHUB_ENV
+
     - name: Configure container storage
       run: |
         sed -i 's/graphroot = .*/graphroot = "\/__w\/container_storage"/' /etc/containers/storage.conf


### PR DESCRIPTION
This commit updates the CI workflow to set the TMPDIR environment variable to `/__w/tmp`, which is under the runner work volume in order to ensure that sufficient free space is available for the temporary image layers to be stored.

Note that the TMPDIR environment variable is used by Podman/Buildah to set `image_copy_tmp_dir`.