### PR TITLE
Dockerfile: Use CI image v0.28.1 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/zephyrproject-rtos/ci:v0.28.0
+FROM ghcr.io/zephyrproject-rtos/ci:v0.28.1
 
 # Cache Zephyr repositories
 RUN mkdir -p /repo-cache/zephyrproject && \


### PR DESCRIPTION
Using 0.17.2 SDK.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
