### PR TITLE
Dockerfile: Use CI image v0.28.3 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/zephyrproject-rtos/ci:v0.28.1
+FROM ghcr.io/zephyrproject-rtos/ci:v0.28.3
 
 # Cache Zephyr repositories
 RUN mkdir -p /repo-cache/zephyrproject && \


### PR DESCRIPTION
This commit updates the Dockerfile to use the CI image v0.28.3 with Zephyr SDK 0.17.3 as the base image.